### PR TITLE
Pin to stable framework version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
 [env]
-platform = https://github.com/zhiquanyeo/platform-raspberrypi.git
+platform = https://github.com/zhiquanyeo/platform-raspberrypi.git#9de6fbb05e7daf4a4ad543d37a7e8f66194b5164
 framework = arduino
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m


### PR DESCRIPTION
Pin the build framework to a known-stable version to allow for future library updates