### PR TITLE
Add battery voltage read

### DIFF
--- a/include/robot.h
+++ b/include/robot.h
@@ -51,11 +51,14 @@
 #define XRP_DATA_AIO 0x04
 #define XRP_DATA_GENERAL 0x08
 
+#define XRP_VIN_MEAS 28
+
 namespace xrp {
 
 void robotInit();
 bool robotInitialized();
 uint8_t robotPeriodic();
+float getVinMeasured();
 
 // Robot control
 void robotSetEnabled(bool enabled);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,6 +162,7 @@ void sendData() {
   if (xrp::rangefinderInitialized()) {
     ptr += wpilibudp::writeAnalogData(2, xrp::getRangefinderDistance5V(), buffer, ptr);
   }
+  ptr += wpilibudp::writeAnalogData(3, xrp::getVinMeasured(), buffer, ptr);
 
   // ptr should now point to 1 past the last byte
   size = ptr;

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -327,6 +327,13 @@ float getReflectanceRight5V() {
   return _readAnalogPinScaled(REFLECT_RIGHT_PIN) * 5.0f;
 }
 
+float getVinMeasured() {
+  //ADC reads are 3.3V max
+  //R1 = 100k, R2 = 33k, voltage divider = R2/(R1+R2)
+  //reading * Vadc_max / volt divider
+  return _readAnalogPinScaled(XRP_VIN_MEAS) * 3.3f / (33.f/(100.f+33.f));
+}
+
 void rangefinderInit() {
   pinMode(ULTRASONIC_TRIG_PIN, OUTPUT); // Trigger Pin
   digitalWrite(ULTRASONIC_TRIG_PIN, LOW);


### PR DESCRIPTION
The XRP robot has a battery voltage pin on it, but it was not configured to be read.  I added that logic to support it.
![image](https://github.com/user-attachments/assets/c98d178f-c142-42fd-ba3d-3803c941dafd)

I choose AnalogInput(3) as the channel in WpiLib to read the value.  Ideally, it probably should have been hooked up to RobotController.getBatteryVoltage(), but I think that is a lot more infrastructure needed to do that.