### PR TITLE
Add network AP channel support

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -13,6 +13,7 @@ class XRPNetConfig {
     NetworkMode mode { NetworkMode::NOT_CONFIGURED };
     std::string defaultAPName {""};
     std::string defaultAPPassword {""};
+    int defaultAPChannel = 0;
     std::vector< std::pair<std::string, std::string> > networkList;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,9 @@ void writeStatusToDisk(NetworkMode netMode, char *chipID) {
   if (netMode == NetworkMode::AP) {
     f.printf("AP SSID: %s\n", config.networkConfig.defaultAPName.c_str());
     f.printf("AP PASS: %s\n", config.networkConfig.defaultAPPassword.c_str());
+    if(config.networkConfig.defaultAPChannel != 0) {
+      f.printf("AP CHAN: %d\n", config.networkConfig.defaultAPChannel);
+    }
   }
   else {
     f.printf("Connected to %s\n", WiFi.SSID().c_str());


### PR DESCRIPTION
This adds the ability to set the AP network channel in the configuration. It assumes the JSON value is an integer like:

    "network": {
        "defaultAP": {
            "ssid": "XRP-c259-6dad",
            "password": "xrp-wpilib",
            "channel": 6
     ....
 